### PR TITLE
update timestamp parameter #397

### DIFF
--- a/cloud-functions/public/scripts/main.js
+++ b/cloud-functions/public/scripts/main.js
@@ -74,7 +74,7 @@ function loadMessages() {
         deleteMessage(change.doc.id);
       } else {
         var message = change.doc.data();
-        displayMessage(change.doc.id, message.timestamp, message.name,
+        displayMessage(change.doc.id, message.timestamp.seconds, message.name,
                        message.text, message.profilePicUrl, message.imageUrl);
       }
     });

--- a/cloud-functions/public/scripts/main.js
+++ b/cloud-functions/public/scripts/main.js
@@ -74,7 +74,7 @@ function loadMessages() {
         deleteMessage(change.doc.id);
       } else {
         var message = change.doc.data();
-        displayMessage(change.doc.id, message.timestamp.seconds, message.name,
+        displayMessage(change.doc.id, message.timestamp.toMillis(), message.name,
                        message.text, message.profilePicUrl, message.imageUrl);
       }
     });


### PR DESCRIPTION
Firestore returns Timestamp object with nanoseconds and seconds. Resolves #397 