### PR TITLE
Remove Firestore settings

### DIFF
--- a/web/public/scripts/main.js
+++ b/web/public/scripts/main.js
@@ -354,8 +354,6 @@ initFirebaseAuth();
 
 // Remove the warning about timstamps change. 
 var firestore = firebase.firestore();
-var settings = {timestampsInSnapshots: true};
-firestore.settings(settings);
 
 // We load currently existing chat messages and listen to new ones.
 loadMessages();


### PR DESCRIPTION
`timestampsInSnapshots: true` is the default now. The Firestore SDK logs a warning if this option is included, so let's remove it.

closes #406 