### PR TITLE
Fix toMillis() called twice on firestore doc message timestamp.

### DIFF
--- a/performance-monitoring-start/public/scripts/main.js
+++ b/performance-monitoring-start/public/scripts/main.js
@@ -74,7 +74,7 @@ function loadMessages() {
         deleteMessage(change.doc.id);
       } else {
         var message = change.doc.data();
-        displayMessage(change.doc.id, message.timestamp.toMillis(), message.name,
+        displayMessage(change.doc.id, message.timestamp, message.name,
                        message.text, message.profilePicUrl, message.imageUrl);
       }
     });

--- a/performance-monitoring/public/scripts/main.js
+++ b/performance-monitoring/public/scripts/main.js
@@ -74,7 +74,7 @@ function loadMessages() {
         deleteMessage(change.doc.id);
       } else {
         var message = change.doc.data();
-        displayMessage(change.doc.id, message.timestamp.toMillis(), message.name,
+        displayMessage(change.doc.id, message.timestamp, message.name,
                        message.text, message.profilePicUrl, message.imageUrl);
       }
     });


### PR DESCRIPTION
Error detail:

Uncaught TypeError: Cannot read property 'toMillis' of null
    at main.js:77
    at Array.forEach (<anonymous>)
    at Object.next (main.js:72)
    at next (database.ts:1973)
    at async_observer.ts:51


It is because `function loadMessages()` has already provided `message.timestamp.toMillis` to `function displayMessage()`